### PR TITLE
Bug: Snippets callback error on empty search

### DIFF
--- a/Query.php
+++ b/Query.php
@@ -321,7 +321,7 @@ class Query extends \yii\db\Query
      */
     protected function fillUpSnippets($rows)
     {
-        if ($this->snippetCallback === null) {
+        if ($this->snippetCallback === null || empty($rows)) {
             return $rows;
         }
         $snippetSources = call_user_func($this->snippetCallback, $rows);


### PR DESCRIPTION
Sphinx daemon throws an error while trying to apply snippets callback to form a SphinxQL request when search request is unsuccessful (no rows fetched). Also there is no sense to try to make snippets on empty search results set.
Error:
SQLSTATE[42000]: Syntax error or access violation: 1064 SNIPPETS() argument 1 must be a string or a string list