### PR TITLE
Match builder

### DIFF
--- a/MatchBuilder.php
+++ b/MatchBuilder.php
@@ -1,0 +1,303 @@
+<?php
+/**
+ * @author Kirichenko Sergey
+ */
+
+namespace yii\sphinx;
+
+use Yii;
+use yii\db\Expression;
+use yii\base\InvalidParamException;
+use yii\helpers\ArrayHelper;
+
+/**
+ * Match Builder
+ */
+class MatchBuilder
+{
+    /**
+     * @var array map of query match to builder methods
+     * These methods are used by [[buildMatch]] to build string inside SQL Match method.
+     */
+    protected $matchBuilders = [
+        'AND' => 'buildAndMatch',
+        'OR' => 'buildAndMatch',
+        'IGNORE' => 'buildIgnoreMatch',
+        'PROXIMITY' => 'buildProximityMatch',
+        'MAYBE' => 'buildMultipleMatch',
+        'SENTENCE' => 'buildMultipleMatch',
+        'PARAGRAPH' => 'buildMultipleMatch',
+        'ZONE' => 'buildZoneMatch',
+        'ZONESPAN' => 'buildZoneMatch',
+    ];
+
+    /**
+     * @var array map of match's operators
+     * These operators are used for replacement regular SQL operators
+     */
+    protected $matchOperators = [
+        'AND' => ' ',
+        'OR' => ' | ',
+        'NOT' => ' !',
+        '=' => ' ',
+    ];
+
+    /**
+     * Create Match Expression
+     * @param string|array $match
+     * @param array $params the binding parameters to be populated
+     * @return string the MATCH Expression
+     */
+    public function buildMatchExpression($match, &$params)
+    {
+        $matchExpression = $this->buildMatch($match, $params);
+        $matchRaw = $this->replaceParams($matchExpression, $params);
+        return new Expression(Yii::$app->sphinx->quoteValue($matchRaw));
+    }
+
+    /**
+     * Create Match clause
+     * @param string|array $match
+     * @param array $params the binding parameters to be populated
+     * @return string the MATCH expression
+     */
+    public function buildMatch($match, &$params)
+    {
+        if(empty($match))
+            return '';
+
+        if($match instanceof Expression || !is_array($match))
+            return $this->composeMatchValue($match, $params);
+
+        // operator format: operator, operand 1, operand 2, ...
+        if (isset($match[0])){
+
+            $operator = strtoupper($match[0]);
+
+            $method = isset($this->matchBuilders[$operator])
+                ? $this->matchBuilders[$operator]
+                : 'buildSimpleMatch';
+
+            array_shift($match);
+
+            return $this->$method($operator, $match, $params);
+        }
+
+        // hash format: 'column1' => 'value1', 'column2' => 'value2', ...
+        return $this->buildHashMatch($match, $params);
+    }
+
+    /**
+     * Creates a match based on column-value pairs.
+     * @param array $match the match condition
+     * @param array $params the binding parameters to be populated
+     * @return string the MATCH expression
+     */
+    public function buildHashMatch($match, &$params)
+    {
+        $parts = [];
+
+        foreach ($match as $column => $value)
+            $parts[] = $this->buildMatchColumn($column) . " " . $this->composeMatchValue($value, $params);
+
+        return count($parts) === 1 ? $parts[0] : '(' . implode(') (', $parts) . ')';
+    }
+
+    /**
+     * Connects two or more MATCH expressions with the `AND` or `OR` operator
+     * @param string $operator the operator which is used for connecting the given operands
+     * @param array $operands the Match expressions to connect
+     * @param array $params the binding parameters to be populated
+     * @return string the MATCH expression
+     */
+    public function buildAndMatch($operator, $operands, &$params)
+    {
+        $parts = [];
+
+        foreach ($operands as $operand) {
+
+            if (is_array($operand) || is_object($operand))
+                $operand = $this->buildMatch($operand, $params);
+
+            if ($operand !== '')
+                $parts[] = $operand;
+        }
+
+        if (!empty($parts))
+            return '(' . implode(") " . ($operator === 'OR' ? '|' : '') . " (", $parts) . ')';
+        else
+            return '';
+    }
+
+    /**
+     * Create Maybe, Sentence or Paragraph Match expressions
+     * @param  string $operator the operator which is used for Create Match expressions
+     * @param  array $operands the Match expressions
+     * @param  array &$params the binding parameters to be populated
+     * @return string the MATCH expression
+     */
+    public function buildMultipleMatch($operator, $operands, &$params)
+    {
+        if (count($operands) < 3)
+            throw new InvalidParamException("Operator '$operator' requires three or more operands.");
+
+        $column = array_shift($operands);
+
+        $phNames = [];
+
+        foreach($operands as $operand)
+            $phNames[] = $this->composeMatchValue($operand, $params);
+
+        return $this->buildMatchColumn($column) . " " . implode(' ' . $operator . ' ', $phNames);
+    }
+
+    /**
+     * Create Match expressions for zones
+     * @param  string $operator the operator which is used for Create Match expressions
+     * @param  array $operands the Match expressions
+     * @param  array &$params the binding parameters to be populated
+     * @return string the MATCH expression
+     */
+    public function buildZoneMatch($operator, $operands, &$params)
+    {
+        if (!isset($operands[0]))
+            throw new InvalidParamException("Operator '$operator' requires exactly one operand.");
+
+        $phNames = [];
+
+        foreach((array)$operands[0] as $zone)
+            $phNames[] = $this->composeMatchValue($zone, $params);
+
+        return "$operator: (" . implode(',', $phNames) . ")";
+    }
+
+    /**
+     * Create Proximity Match expressions
+     * @param  string $operator the operator which is used for Create Match expressions
+     * @param  array $operands the Match expressions
+     * @param  array &$params the binding parameters to be populated
+     * @return string the MATCH expression
+     */
+    public function buildProximityMatch($operator, $operands, &$params)
+    {
+        if (!isset($operands[0], $operands[1], $operands[2]))
+            throw new InvalidParamException("Operator '$operator' requires three operands.");
+
+        list($column, $value, $proximity) = $operands;
+
+        return $this->buildMatchColumn($column) . " " . $this->composeMatchValue($value, $params) . "~" . (int) $proximity;
+    }
+
+    /**
+     * Create Ignored Match expressions
+     * @param  string $operator the operator which is used for Create Match expressions
+     * @param  array $operands the Match expressions
+     * @param  array &$params the binding parameters to be populated
+     * @return string the MATCH expression
+     */
+    public function buildIgnoreMatch($operator, $operands, &$params)
+    {
+        if (!isset($operands[0], $operands[1]))
+            throw new InvalidParamException("Operator '$operator' requires two operands.");
+
+        list($column, $value) = $operands;
+
+        return $this->buildMatchColumn($column, true) . " " . $this->composeMatchValue($value, $params);
+    }
+
+    /**
+     * Creates an Match expressions like `"column" operator value`.
+     * @param string $operator the operator to use. Anything could be used e.g. `>`, `<=`, etc.
+     * @param array $operands contains two column names.
+     * @param array $params the binding parameters to be populated
+     * @return string the Created SQL expression
+     * @throws InvalidParamException if count($operands) is not 2
+     */
+    public function buildSimpleMatch($operator, $operands, &$params)
+    {
+        if (count($operands) !== 2)
+            throw new InvalidParamException("Operator '$operator' requires two operands.");
+
+        list($column, $value) = $operands;
+
+        return $this->buildMatchColumn($column) .
+        ArrayHelper::getValue($this->matchOperators, $operator, $operator) .
+        $this->composeMatchValue($value, $params);
+    }
+
+    /**
+     * Create placeholder for expression of Match
+     * @param string|array|Expression $value   [description]
+     * @param array &$params the binding parameters to be populated
+     * @return string the MATCH expression
+     */
+    protected function composeMatchValue($value, &$params)
+    {
+        if ($value === null) {
+            return '""';
+        } elseif ($value instanceof Expression) {
+            $params = array_merge($params, $value->params);
+            return $value->expression;
+        }
+
+        $parts = [];
+        foreach ((array) $value as $v) {
+            if ($v instanceof Expression) {
+                $params = array_merge($params, $v->params);
+                $parts[] = $v->expression;
+            } else {
+                $phName = QueryBuilder::PARAM_PREFIX . count($params);
+                $parts[] = '"' . $phName . '"';
+                $params[$phName] = $v;
+            }
+        }
+
+        if(count($parts) === 0)
+            return '""';
+
+        return implode(' | ', $parts);
+    }
+
+    /**
+     * Created column as string for expression of Match
+     * @param  string  $column
+     * @param  boolean $ignored
+     * @return string the column as string
+     */
+    protected function buildMatchColumn($column, $ignored = false)
+    {
+        if(empty($column))
+            return '';
+
+        if($column === '*')
+            return '@*';
+
+        return '@' . ($ignored ? '!' : '') .
+        (strpos($column, ',') === false
+            ? $column
+            : '(' . $column . ')'
+        );
+    }
+
+    /**
+     * Returns the expression of Match by inserting parameter values into the corresponding placeholders
+     * @param  string $sql the expression string which is needed to prepare
+     * @param  array $params the binding parameters for inserting
+     * @return string
+     */
+    protected function replaceParams($sql, &$params)
+    {
+        if(empty($params))
+            return $sql;
+
+        foreach ($params as $name => $value) {
+            $pattern = "/" . preg_quote($name, '/') . '\b/';
+            $sql = preg_replace($pattern, Yii::$app->sphinx->escapeMatchValue($value), $sql, -1, $cnt);
+            if ($cnt > 0) {
+                unset($params[$name]);
+            }
+        }
+
+        return $sql;
+    }
+}

--- a/MatchBuilder.php
+++ b/MatchBuilder.php
@@ -5,16 +5,21 @@
 
 namespace yii\sphinx;
 
-use Yii;
 use yii\db\Expression;
 use yii\base\InvalidParamException;
 use yii\helpers\ArrayHelper;
+use yii\base\Object;
 
 /**
  * Match Builder
  */
-class MatchBuilder
+class MatchBuilder extends Object
 {
+    /**
+     * @var Connection the Sphinx connection.
+     */
+    public $db;
+
     /**
      * @var array map of query match to builder methods
      * These methods are used by [[buildMatch]] to build string inside SQL Match method.
@@ -55,7 +60,7 @@ class MatchBuilder
 
         $matchExpression = $this->buildMatch($match, $params);
         $matchRaw = $this->replaceParams($matchExpression, $params);
-        return new Expression(Yii::$app->sphinx->quoteValue($matchRaw));
+        return new Expression($this->db->quoteValue($matchRaw));
     }
 
     /**
@@ -295,7 +300,7 @@ class MatchBuilder
 
         foreach ($params as $name => $value) {
             $pattern = "/" . preg_quote($name, '/') . '\b/';
-            $sql = preg_replace($pattern, Yii::$app->sphinx->escapeMatchValue($value), $sql, -1, $cnt);
+            $sql = preg_replace($pattern, $this->db->escapeMatchValue($value), $sql, -1, $cnt);
             if ($cnt > 0) {
                 unset($params[$name]);
             }

--- a/MatchBuilder.php
+++ b/MatchBuilder.php
@@ -50,6 +50,9 @@ class MatchBuilder
      */
     public function buildMatchExpression($match, &$params)
     {
+        if($match instanceof Expression)
+            return $match;
+
         $matchExpression = $this->buildMatch($match, $params);
         $matchRaw = $this->replaceParams($matchExpression, $params);
         return new Expression(Yii::$app->sphinx->quoteValue($matchRaw));

--- a/Query.php
+++ b/Query.php
@@ -257,23 +257,51 @@ class Query extends \yii\db\Query
     }
 
     /**
-     * Sets the fulltext query text. This text will be composed into
-     * MATCH operator inside the WHERE clause.
-     * Note: this value will be processed by [[Connection::escapeMatchValue()]],
-     * if you need to compose complex match condition use [[Expression]]:
-     * ~~~
-     * $query = new Query();
-     * $query->from('my_index')
-     *     ->match(new Expression(':match', ['match' => '@(content) ' . Yii::$app->sphinx->escapeMatchValue($matchValue)]))
-     *     ->all();
-     * ~~~
-     *
-     * @param string $query fulltext query text.
+     * Sets the MATCH part of the WHERE condition.
+     * @param  array|string|Expression $match
      * @return $this the query object itself
+     * @see andMatch()
+     * @see orMatch()
      */
-    public function match($query)
+    public function match($match)
     {
-        $this->match = $query;
+        $this->match = $match;
+        return $this;
+    }
+
+    /**
+     * Adds an additional MATCH condition to the existing one.
+     * The new condition and the existing one will be joined.
+     * @param  array|string|Expression $match
+     * @return $this the query object itself
+     * @see match()
+     * @see orMatch()
+     */
+    public function andMatch($match)
+    {
+        if ($this->match === null) {
+            $this->match = $match;
+        } else {
+            $this->match = ['and', $this->match, $match];
+        }
+        return $this;
+    }
+
+    /**
+     * Adds an additional MATCH condition to the existing one.
+     * The new condition and the existing one will be joined using the '|' operator.
+     * @param  array|string|Expression $match
+     * @return $this the query object itself
+     * @see match()
+     * @see andMatch()
+     */
+    public function orMatch($match)
+    {
+        if ($this->match === null) {
+            $this->match = $match;
+        } else {
+            $this->match = ['or', $this->match, $match];
+        }
         return $this;
     }
 

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -540,14 +540,8 @@ class QueryBuilder extends Object
     public function buildWhere($indexes, $condition, &$params, $match = null)
     {
         if ($match !== null) {
-            if ($match instanceof Expression) {
-                $matchWhere = 'MATCH(' . $match->expression . ')';
-                $params = array_merge($params, $match->params);
-            } else {
-                $phName = self::PARAM_PREFIX . count($params);
-                $params[$phName] = $this->db->escapeMatchValue($match);
-                $matchWhere = 'MATCH(' . $phName . ')';
-            }
+            $matchBuilder = new MatchBuilder();
+            $matchWhere = 'MATCH(' . $matchBuilder->buildMatchExpression($match, $params) . ')';
 
             if ($condition === null) {
                 $condition = $matchWhere;

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -541,7 +541,7 @@ class QueryBuilder extends Object
     {
         if ($match !== null) {
             $matchBuilder = new MatchBuilder(['db' => $this->db]);
-            $matchWhere = 'MATCH(' . $matchBuilder->buildMatchExpression($match, $params) . ')';
+            $matchWhere = $matchBuilder->buildMatchWhere($match, $params);
 
             if ($condition === null) {
                 $condition = $matchWhere;

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -540,7 +540,7 @@ class QueryBuilder extends Object
     public function buildWhere($indexes, $condition, &$params, $match = null)
     {
         if ($match !== null) {
-            $matchBuilder = new MatchBuilder();
+            $matchBuilder = new MatchBuilder(['db' => $this->db]);
             $matchWhere = 'MATCH(' . $matchBuilder->buildMatchExpression($match, $params) . ')';
 
             if ($condition === null) {


### PR DESCRIPTION
### Builder for match expressions.
Allows you to work with match expressions. It look like a work with QueryBuilder. New methods match(), andMatch() and orMatch() works exactly like where(), andWhere() and orWhere().

###### Simple conditions.
```php
Post::find()
	->andMatch(['tags' => ['fruits', 'berries']])
	->andMatch(['name,title' => new \yii\db\Expression('apple *:kind*', [':kind' => 'red'])])
	->all();
```
```sql
SELECT * FROM `post` WHERE MATCH('(@tags \"fruits\" | \"berries\")  (@(name,title) apple *red*)');
```

###### Conditions with typical operators.
```php
Product::find()
	->andMatch([
		'or', 
		[‘not’, 'filter', 'internet:4G'],
		[‘=‘, 'filter', ['memory:32GB', 'memory:64GB']], 
	])
	->all();
```
```sql
SELECT * FROM `product` WHERE MATCH('(@filter !\"internet:4G\") | (@filter \"memory:32GB\" | \"memory:64GB\")');
```

###### Specific operators for Sphinx: ignore, proximity, maybe, sentence, paragraph, zone and zonespan.
```php
Post::find()
	->andMatch([
		'maybe', 
		'title', 
		'My first post',
		new \yii\db\Expression('*:title*', [':title' => 'article'])
	])
	->all();
```
```sql
SELECT * FROM `post` MATCH('@title \"My first post\" MAYBE *article*');
```

###### Support backward compatibility
```php
Post::find()
	->match(new Expression(':match', ['match' => '@(content) ' . Yii::$app->sphinx->escapeMatchValue(“matchValue”)]))
	->all();
```
```sql
SELECT * FROM `post` MATCH('@(content) matchValue');
```