### PR TITLE
Fixed distributed agents

### DIFF
--- a/Schema.php
+++ b/Schema.php
@@ -471,7 +471,11 @@ class Schema extends Object
             }
         } else {
             // Distributed index :
-            $agent = $this->getIndexSchema($columns[0]['Agent']);
+            foreach($columns as $column) {
+                $agent = $this->getIndexSchema($column['Agent']);
+                if($agent)
+                    break;
+            }
             $index->columns = $agent->columns;
             $index->primaryKey = $agent->primaryKey;
         }


### PR DESCRIPTION
Currently `yii2-sphinx` tries to detect the agent of a distributed index using the first index. This leads to problems, when the first index is not loaded in sphinx.

Example sphinx.conf:

    index idx_distri {
        type = distributed
        local = idx_local1
        local = idx_local2
        local = idx_local3
    }

If only `idx_local2` and `idx_local3` are loaded in sphinx, `yii2-sphinx` fails because it tries to get the agent using the first local index. This is not wanted sphinx behaviour, because `sphinxql` works without any problems in this use-case.

I've modified the agent detection so that it always takes the agent of the first available index.