### PR TITLE
fix empty MVA field population

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -631,8 +631,12 @@ abstract class ActiveRecord extends BaseActiveRecord
         foreach ($row as $name => $value) {
             if (isset($columns[$name])) {
                 if ($columns[$name]->isMva) {
-                    $mvaValue = explode(',', $value);
-                    $row[$name] = array_map([$columns[$name], 'phpTypecast'], $mvaValue);
+                    if ($value === '') {
+                        $row[$name] = [];
+                    } else {
+                        $mvaValue = explode(',', $value);
+                        $row[$name] = array_map([$columns[$name], 'phpTypecast'], $mvaValue);
+                    }
                 } else {
                     $row[$name] = $columns[$name]->phpTypecast($value);
                 }


### PR DESCRIPTION
Empty MVA field is casted to "[NULL]" (array with null element) instead of "[]" (empty array)

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #75

No additional tests provided with this PR