### PR TITLE
Convert nulls to empty strings before calling Sphinx’s internal snippet function

### DIFF
--- a/Query.php
+++ b/Query.php
@@ -511,7 +511,11 @@ class Query extends \yii\db\Query
      */
     protected function callSnippets(array $source)
     {
-        return $this->callSnippetsInternal($source, $this->from[0]);
+        $noNulls = [];
+        foreach ($source as $value) {
+            $noNulls []= $value !== null ? $value : '';
+        }
+        return $this->callSnippetsInternal($noNulls, $this->from[0]);
     }
 
     /**


### PR DESCRIPTION
Without this the module will fail sometimes with one of two exceptions:

![2017-12-27 15-24-32](https://user-images.githubusercontent.com/980679/34381606-9b8235a4-eb1a-11e7-98ac-c7ebb40799a9.png)

![image](https://user-images.githubusercontent.com/980679/34381630-d0a6a5ee-eb1a-11e7-9cfc-7fff4a93b65f.png)

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
