### PR TITLE
BugFix for #101

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -180,15 +180,7 @@ class Query extends \yii\db\Query
         list ($sql, $params) = $db->getQueryBuilder()->build($this);
 
         return $db->createCommand($sql, $params);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function populate($rows)
-    {
-        return parent::populate($this->fillUpSnippets($rows));
-    }
+    }    
 
     /**
      * {@inheritdoc}
@@ -260,8 +252,8 @@ class Query extends \yii\db\Query
             }
         }
 
-        // rows should be populated after all data read from cursor, avoiding possible 'unbuffered query' error
-        $rows = $this->populate($rawRows);
+        // rows should be populated after all data read from cursor, avoiding possible 'unbuffered query' error      
+        $rows = $this->populate($this->fillUpSnippets($rawRows));
 
         return [
             'hits' => $rows,


### PR DESCRIPTION
Fixes: indexBy was not working, as parent::populate() was never called in ActiveRecord::populate().
fillupSnippets was called on models instead on array for ActiveQuery::populate().

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #101 
