### PR TITLE
BugFix for #101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 sphinx extension Change Log
 2.0.11 under development
 ------------------------
 
-- Bug #101: Fixed `yii\sphinx\ActiveQuery::all()` unable to follow instructions given by method `indexBy()`.
+- Bug #101: Fixed `yii\sphinx\ActiveQuery::all()` unable to follow instructions given by method `indexBy()` (bitdevelopment)
 
 
 2.0.10 February 13, 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 sphinx extension Change Log
 2.0.11 under development
 ------------------------
 
-- no changes in this release.
+- Bug #101: Fixed `yii\sphinx\ActiveQuery::all()` unable to follow instructions given by method `indexBy()`.
 
 
 2.0.10 February 13, 2018

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -156,7 +156,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     public function all($db = null)
     {
-	if ($this->emulateExecution) {
+        if ($this->emulateExecution) {
             return [];
         }
         $rows = $this->createCommand($db)->queryAll();

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -191,6 +191,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             return [];
         }
 
+        $models = $this->createModels($rows);
         if (!empty($this->with)) {
             $this->findWith($this->with, $models);
         }

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -191,13 +191,13 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             return [];
         }
         
-        $rows = $this->fillUpSnippets($rows);
+        
 
         $models = $this->createModels($rows);
         if (!empty($this->with)) {
             $this->findWith($this->with, $models);
         }
-        
+        $rows = $this->fillUpSnippets($models);
         if (!$this->asArray) {
             foreach ($models as $model) {
                 $model->afterFind();

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -156,7 +156,11 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      */
     public function all($db = null)
     {
-        return parent::all($db);
+	if ($this->emulateExecution) {
+            return [];
+        }
+        $rows = $this->createCommand($db)->queryAll();
+        return $this->populate($this->fillUpSnippets($rows));
     }
 
     /**
@@ -176,18 +180,6 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         } else {
             return null;
         }
-    }
-    
-    /**
-     * {@inheritdoc}
-     */
-    public function all($db = null)
-    {
-        if ($this->emulateExecution) {
-            return [];
-        }
-        $rows = $this->createCommand($db)->queryAll();
-        return $this->populate($this->fillUpSnippets([$row]));
     }
 
     /**

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -197,7 +197,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         if (!empty($this->with)) {
             $this->findWith($this->with, $models);
         }
-        $rows = $this->fillUpSnippets($models);
+        $models = $this->fillUpSnippets($models);
         if (!$this->asArray) {
             foreach ($models as $model) {
                 $model->afterFind();

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -160,7 +160,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             return [];
         }
         $rows = $this->createCommand($db)->queryAll();
-        return $this->populate($this->fillUpSnippets($rows));
+        return $this->populate($rows);
     }
 
     /**
@@ -175,7 +175,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     {
         $row = parent::one($db);
         if ($row !== false) {
-            $models = $this->populate($this->fillUpSnippets([$row]));
+            $models = $this->populate([$row]);
             return reset($models) ?: null;
         } else {
             return null;

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -191,9 +191,6 @@ class ActiveQuery extends Query implements ActiveQueryInterface
             return [];
         }
 
-        $rows = $this->fillUpSnippets($rows);
-
-        $models = $this->createModels($rows);
         if (!empty($this->with)) {
             $this->findWith($this->with, $models);
         }

--- a/src/Query.php
+++ b/src/Query.php
@@ -180,15 +180,7 @@ class Query extends \yii\db\Query
         list ($sql, $params) = $db->getQueryBuilder()->build($this);
 
         return $db->createCommand($sql, $params);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function populate($rows)
-    {
-        return parent::populate($this->fillUpSnippets($rows));
-    }
+    }    
 
     /**
      * {@inheritdoc}
@@ -260,8 +252,8 @@ class Query extends \yii\db\Query
             }
         }
 
-        // rows should be populated after all data read from cursor, avoiding possible 'unbuffered query' error
-        $rows = $this->populate($rawRows);
+        // rows should be populated after all data read from cursor, avoiding possible 'unbuffered query' error      
+        $rows = $this->populate($this->fillUpSnippets($rawRows));
 
         return [
             'hits' => $rows,

--- a/src/Query.php
+++ b/src/Query.php
@@ -185,6 +185,14 @@ class Query extends \yii\db\Query
     /**
      * {@inheritdoc}
      */
+    public function all($db = null)
+    {
+        return $this->fillUpSnippets(parent::all($db));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function one($db = null)
     {
         $row = parent::one($db);

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -30,4 +30,11 @@ class ActiveQueryTest extends TestCase
         $this->assertNotEmpty($results['facets']['author_id'], 'Unable to fill up facet');
         $this->assertTrue($results['hits'][0] instanceof ArticleIndex, 'Unable to populate results as AR object');
     }
+
+    public function testIndexBy() 
+    {
+        $results = ArticleIndex::find()->indexBy(['id'])->all();
+        $result = reset($results);
+        $this->assertTrue($result->id == key($results), 'Unable to index results by column');
+    }
 }

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -3,7 +3,7 @@
 namespace yiiunit\extensions\sphinx;
 
 use yiiunit\extensions\sphinx\data\ar\ArticleIndex;
-use yiiunit\extensions\sphinx\data\ar\ActiveRecord;
+use yiiunit\extensions\sphinx\data\ar\ActiveRecord; 
 
 /**
  * @group sphinx
@@ -33,8 +33,8 @@ class ActiveQueryTest extends TestCase
 
     public function testIndexBy() 
     {
-        $results = ArticleIndex::find()->indexBy(['id'])->all();
-        $result = reset($results);
+        $results = ArticleIndex::find()->indexBy('id')->all();
+        $result = reset($results); 
         $this->assertTrue($result->id == key($results), 'Unable to index results by column');
     }
 }

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -33,7 +33,7 @@ class ActiveQueryTest extends TestCase
 
     public function testIndexBy() 
     {
-        $results = ArticleIndex::find()->indexBy('id')->all();
+        $results = ArticleIndex::find()->indexBy(['id'])->all();
         $result = reset($results);
         $this->assertTrue($result->id == key($results), 'Unable to index results by column');
     }

--- a/tests/ActiveQueryTest.php
+++ b/tests/ActiveQueryTest.php
@@ -33,7 +33,7 @@ class ActiveQueryTest extends TestCase
 
     public function testIndexBy() 
     {
-        $results = ArticleIndex::find()->indexBy(['id'])->all();
+        $results = ArticleIndex::find()->indexBy('id')->all();
         $result = reset($results);
         $this->assertTrue($result->id == key($results), 'Unable to index results by column');
     }


### PR DESCRIPTION
Fixes: indexBy was not working, as parent::populate() was never called in ActiveRecord::populate().
fillupSnippets was called on models instead on array for ActiveQuery::populate().

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #101 
