### PR TITLE
Fix models's population in search() method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ services:
 
 sudo: true
 
+# xenial doesn't support PHP 5.4 - 5.5 (https://travis-ci.community/t/php-5-4-and-5-5-archives-missing/3723)
+# and can't install sphinxsearch
+dist: trusty
+
 # cache vendor dirs
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 sphinx extension Change Log
 2.0.13 under development
 ------------------------
 
-- Bug #114: Fixes exception "Call to a member function getSnippetSource() on array" when call `\yii\sphinx\ActiveQuery::search` (broken by v2.0.11).
+- Bug #114: Fixes exception "Call to a member function getSnippetSource() on array" when call `\yii\sphinx\ActiveQuery::search` broken by v2.0.11 (miketsoft)
 
 
 2.0.12 July 02, 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 sphinx extension Change Log
 2.0.13 under development
 ------------------------
 
-- no changes in this release.
+- Bug #114: Fixes exception "Call to a member function getSnippetSource() on array" when call `\yii\sphinx\ActiveQuery::search` (broken by v2.0.11).
 
 
 2.0.12 July 02, 2019

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -152,15 +152,11 @@ class ActiveQuery extends Query implements ActiveQueryInterface
      * Executes query and returns all results as an array.
      * @param Connection $db the DB connection used to create the DB command.
      * If null, the DB connection returned by [[modelClass]] will be used.
-     * @return array the query results. If the query results in nothing, an empty array will be returned.
+     * @return array|ActiveRecord[] the query results. If the query results in nothing, an empty array will be returned.
      */
     public function all($db = null)
     {
-        if ($this->emulateExecution) {
-            return [];
-        }
-        $rows = $this->createCommand($db)->queryAll();
-        return $this->populate($rows);
+        return parent::all($db);
     }
 
     /**
@@ -195,14 +191,14 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         if (!empty($this->with)) {
             $this->findWith($this->with, $models);
         }
-        $models = $this->fillUpSnippets($models);
+        $models = parent::populate($models);
         if (!$this->asArray) {
             foreach ($models as $model) {
                 $model->afterFind();
             }
         }
 
-        return parent::populate($models);
+        return $models;
     }
 
     /**

--- a/src/Query.php
+++ b/src/Query.php
@@ -185,9 +185,9 @@ class Query extends \yii\db\Query
     /**
      * {@inheritdoc}
      */
-    public function all($db = null)
+    public function populate($rows)
     {
-        return $this->fillUpSnippets(parent::all($db));
+        return parent::populate($this->fillUpSnippets($rows));
     }
 
     /**
@@ -261,7 +261,7 @@ class Query extends \yii\db\Query
         }
 
         // rows should be populated after all data read from cursor, avoiding possible 'unbuffered query' error
-        $rows = $this->populate($this->fillUpSnippets($rawRows));
+        $rows = $this->populate($rawRows);
 
         return [
             'hits' => $rows,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #114

**Russian:** ошибка, вызвавшая #101, появилась из-за того, что в `\yii\sphinx\ActiveQuery::populate` не вызывался родительский метод, который, в конечном счете (в `\yii\db\Query::populate`) обрабатывает поле `$indexBy` запроса. Из-за изменений в 2.0.11, метод `\yii\sphinx\Query::fillUpSnippets` вызвался два раза: в `\yii\sphinx\ActiveQuery::populate:198` и в родительском методе `\yii\sphinx\Query::populate:190`.
**English:** #101 is caused by bug in `\yii\sphinx\ActiveQuery::populate` - method doesn't call it's parent method, which process query's `$indexBy` field (more precisely - `\yii\db\Query::populate`). Changes in 2.0.11 leads to redundant calls for `\yii\sphinx\Query::fillUpSnippets`: in `\yii\sphinx\ActiveQuery::populate:198` and in parent's `\yii\sphinx\Query::populate:190`.
