### PR TITLE
#127 Undefined array key in facets php8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 sphinx extension Change Log
 2.0.15 under development
 ------------------------
 
-- no changes in this release.
+- Bug #127: Fixed warning "Undefined array key" in yii2-sphinx/src/Query.php:248 at facets collecting when moving to php8.1
 
 
 2.0.14 December 30, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 sphinx extension Change Log
 2.0.15 under development
 ------------------------
 
-- Bug #127: Fixed warning "Undefined array key" in yii2-sphinx/src/Query.php:248 at facets collecting when moving to php8.1
+- Bug #127: Fixed warning "Undefined array key" in Query at facets collecting when moving to PHP 8.1 (kulikov6)
 
 
 2.0.14 December 30, 2021

--- a/src/Query.php
+++ b/src/Query.php
@@ -245,7 +245,7 @@ class Query extends \yii\db\Query
             }
 
             foreach ($rawFacetResults as $rawFacetResult) {
-                $rawFacetResult['value'] = $rawFacetResult[strtolower($facet['value'])];
+                $rawFacetResult['value'] = isset($rawFacetResult[strtolower($facet['value'])]) ? $rawFacetResult[strtolower($facet['value'])] : null;
                 $rawFacetResult['count'] = $rawFacetResult[$facet['count']];
                 $facets[$facet['name']][] = $rawFacetResult;
             }


### PR DESCRIPTION
We have to use isset() for backward compatibility with php5, not ?? unfortunately

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #127
